### PR TITLE
fix(map): now the options are used in the map constructor

### DIFF
--- a/src/map/map.js
+++ b/src/map/map.js
@@ -5,7 +5,7 @@ import MapMarkers from './markers'
 
 const EPS = 0.00001
 
-const MapComponent = ({ children, style, defaultCenter, defaultZoom, onGoogleApiLoaded, onChange, ...props }) => {
+const MapComponent = ({ children, style, defaultCenter, defaultZoom, onGoogleApiLoaded, onChange, options, ...props }) => {
 	const mapRef = useRef(null)
 	const prevBoundsRef = useRef(null)
 	const [map, setMap] = useState(null)
@@ -39,6 +39,7 @@ const MapComponent = ({ children, style, defaultCenter, defaultZoom, onGoogleApi
 				new window.google.maps.Map(mapRef.current, {
 					center: defaultCenter,
 					zoom: defaultZoom,
+					...options,
 					...props,
 				})
 			)


### PR DESCRIPTION
Hi,

We found a bug in the library, currently a spread operator was made in the Map constructor but this pass the options object to the current option object so this is incorrect. I extracted the options prop and added a spread of this to the new Map.

```js
  // Before
  useEffect(() => {
    if (mapRef.current && !map) {
      setMap(
        new window.google.maps.Map(mapRef.current, {
          center: defaultCenter,
          zoom: defaultZoom,
          ...props,
        })
      );
      setMaps(window.google.maps);
    }
  }, [defaultCenter, defaultZoom, map, mapRef, props]);

  // After
  useEffect(() => {
    if (mapRef.current && !map) {
      setMap(
        new window.google.maps.Map(mapRef.current, {
          center: defaultCenter,
          zoom: defaultZoom,
          ...options,
          ...props,
        })
      );
      setMaps(window.google.maps);
    }
  }, [defaultCenter, defaultZoom, map, mapRef, props]);
``