### PR TITLE
[refactor] make a function more reliable

### DIFF
--- a/src/map/map.tsx
+++ b/src/map/map.tsx
@@ -22,7 +22,7 @@ function MapComponent({
 	events = [],
 }: MapProps) {
 	const mapRef = useRef<HTMLDivElement>(null)
-	const prevBoundsRef = useRef<number[] | undefined>()
+	const prevBoundsRef = useRef<number[]>([])
 	const [map, setMap] = useState<Map>()
 	const [maps, setMaps] = useState<MapsLibrary>()
 	const [googleApiCalled, setGoogleApiCalled] = useState<boolean>(false)

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,4 @@
-export const isArraysEqualEps = (arrayA: number[], arrayB?: number[], eps = 0.000001): boolean => {
+export const isArraysEqualEps = (arrayA: number[], arrayB: number[], eps = 0.000001): boolean => {
 	if (arrayA && arrayB) {
 		for (let i = 0; i !== arrayA.length; ++i) {
 			if (Math.abs(arrayA[i] - arrayB[i]) > eps) {


### PR DESCRIPTION
I believe that ```isArrayEqualEps``` should mandate two arrays as parameters, yet the second parameter is currently optional.

I propose setting the initial value of ```prevBounsRef``` as an empty array and making the second parameter of ```isArrayEqualEps``` obligatory.

The [useRef type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L1049) is structured as follows, and the existing reference code aligns with the third type:

![image](https://github.com/giorgiabosello/google-maps-react-markers/assets/81841082/852e35b8-9449-4f6c-896e-760d8d7b001d)

and this pr makes ref code aligend with the second type