### PR TITLE
fix(lint): fix lint error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,9 @@
 		"no-plusplus": "off",
 		"no-unused-vars": "off",
 		"no-use-before-define": "off",
-		"prettier/prettier": "error",
+		"prettier/prettier": ["error", {
+			"endOfLine": "auto"
+		}],
 		"react/destructuring-assignment": "off",
 		"react/function-component-definition": "off",
 		"react/jsx-filename-extension": "off",


### PR DESCRIPTION
## Why

Window and Linux handle the line break differently, with Window using CRLF and Linux using LF. due to this difference, errors occur in an Window environment. i have modified the code to resolve these errors.

## Image
![image](https://github.com/giorgiabosello/google-maps-react-markers/assets/81841082/c00e7672-cad4-44a8-b497-e76b2748e16e)


## Reference
https://stackoverflow.com/a/67305884

