### PR TITLE
fix(package): fix package cjs import/require

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,14 @@
 		"google-maps-react-markers",
 		"react-component"
 	],
-	"main": "dist/index.js",
+	"main": "dist/index.cjs",
 	"module": "dist/index.js",
+	"exports": {
+		".": {
+			"import": "./dist/index.js",
+			"require": "./dist/index.cjs"
+		}
+	},
 	"types": "dist/index.d.ts",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
Current version of the package doesn't export properly the commonjs dist. It leads to errors like "Error [ERR_REQUIRE_ESM]: require() of ES Module"

Solution based on :
- https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html (Package.json paragraph at the end)
- https://nodejs.org/api/packages.html#packages_conditional_exports

Tried on my side (Typescript project using CommonJs require after transpilation) it works. 
