### PR TITLE
fix: rerender overlay on draggable prop change for correct drag implementation

### DIFF
--- a/src/map/overlay-view.tsx
+++ b/src/map/overlay-view.tsx
@@ -28,8 +28,8 @@ const OverlayView = ({
 	// This fixes the issue where the overlay is not updated when the position changes.
 	const childrenProps = useMemoCompare(
 		children?.props as any,
-		(prev: { lat: any; lng: any }, next: { lat: any; lng: any }) =>
-			prev && prev.lat === next.lat && prev.lng === next.lng,
+		(prev: { lat: any; lng: any; draggable: boolean }, next: { lat: any; lng: any; draggable: boolean }) =>
+			prev && prev.lat === next.lat && prev.lng === next.lng && prev.draggable === next.draggable; ,
 	)
 
 	useEffect(() => {


### PR DESCRIPTION


Current issue:
We have different modes for drawing figures on the map and placing markers, that is why draggable prop is changed dynamically depending on the mode selected. At the moment to rerender overlay we do deep comparison only on lat and lng props change, do not taking into account draggable prop which causes incorrect behaviour