### PR TITLE
Revert "fix: rerender overlay on draggable prop change for correct drag implementation"

### DIFF
--- a/src/map/overlay-view.tsx
+++ b/src/map/overlay-view.tsx
@@ -28,8 +28,8 @@ const OverlayView = ({
 	// This fixes the issue where the overlay is not updated when the position changes.
 	const childrenProps = useMemoCompare(
 		children?.props as any,
-		(prev: { lat: any; lng: any; draggable: boolean }, next: { lat: any; lng: any; draggable: boolean }) =>
-			prev && prev.lat === next.lat && prev.lng === next.lng && prev.draggable === next.draggable; ,
+		(prev: { lat: any; lng: any }, next: { lat: any; lng: any }) =>
+			prev && prev.lat === next.lat && prev.lng === next.lng,
 	)
 
 	useEffect(() => {


### PR DESCRIPTION
Reverts giorgiabosello/google-maps-react-markers#317 because of typing errors.